### PR TITLE
Countermeasures and lock on improvements

### DIFF
--- a/v2.0/Elite 2.0.tmc
+++ b/v2.0/Elite 2.0.tmc
@@ -26,10 +26,10 @@ int main() {
 	SetSCurve(&Joystick, JOYX, 0, 0, 0, 0, 0);
 	MapAxis(&Joystick, JOYY, DX_Y_AXIS, AXIS_NORMAL, MAP_ABSOLUTE);
 	SetSCurve(&Joystick, JOYY, 0, 0, 0, 0, 0);
-	MapAxis(&Throttle, SCX, DX_XROT_AXIS, AXIS_NORMAL, MAP_ABSOLUTE);
-	SetSCurve(&Throttle, SCX, 0, 0, 0, 0, 0);
-	MapAxis(&Throttle, SCY, DX_YROT_AXIS, AXIS_NORMAL, MAP_ABSOLUTE);
-	SetSCurve(&Throttle, SCY, 0, 0, 0, 0, 0);
+	MapAxis(&Throttle, SCX, MOUSE_X_AXIS, AXIS_NORMAL, MAP_RELATIVE);
+	SetSCurve(&Throttle, SCX, 0, 0, 0, 20, -5);
+	MapAxis(&Throttle, SCY, MOUSE_Y_AXIS, AXIS_NORMAL, MAP_RELATIVE);
+	SetSCurve(&Throttle, SCY, 0, 0, 0, 20, -5);
 	MapAxis(&Throttle, THR_RIGHT, DX_Z_AXIS, AXIS_NORMAL, MAP_ABSOLUTE);
 	SetSCurve(&Throttle, THR_RIGHT, 0, 0, 0, 0, 0);
 	MapAxis(&Throttle, THR_LEFT, DX_ZROT_AXIS, AXIS_NORMAL, MAP_ABSOLUTE);

--- a/v2.0/Elite 2.0.tmc
+++ b/v2.0/Elite 2.0.tmc
@@ -7,6 +7,9 @@ char selected_wingman;
 int FSD_commands;
 char FSD_mode;	// 1 => hyperspace, 2 => supercruise, 3 => wing nav lock
 
+int countermeasure_commands;
+char selected_countermeasure;
+
 int main() {
 	// Which physical devices we have
 	Configure(&HCougar, MODE_EXCLUDED);
@@ -26,16 +29,20 @@ int main() {
 	SetSCurve(&Joystick, JOYX, 0, 0, 0, 0, 0);
 	MapAxis(&Joystick, JOYY, DX_Y_AXIS, AXIS_NORMAL, MAP_ABSOLUTE);
 	SetSCurve(&Joystick, JOYY, 0, 0, 0, 0, 0);
-	MapAxis(&Throttle, SCX, MOUSE_X_AXIS, AXIS_NORMAL, MAP_RELATIVE);
-	SetSCurve(&Throttle, SCX, 0, 0, 0, 20, -5);
-	MapAxis(&Throttle, SCY, MOUSE_Y_AXIS, AXIS_NORMAL, MAP_RELATIVE);
-	SetSCurve(&Throttle, SCY, 0, 0, 0, 20, -5);
 	MapAxis(&Throttle, THR_RIGHT, DX_Z_AXIS, AXIS_NORMAL, MAP_ABSOLUTE);
 	SetSCurve(&Throttle, THR_RIGHT, 0, 0, 0, 0, 0);
 	MapAxis(&Throttle, THR_LEFT, DX_ZROT_AXIS, AXIS_NORMAL, MAP_ABSOLUTE);
 	SetSCurve(&Throttle, THR_LEFT, 0, 0, 0, 0, 0);
 	MapAxis(&Throttle, THR_FC, DX_SLIDER_AXIS, AXIS_NORMAL, MAP_ABSOLUTE);
 	SetSCurve(&Throttle, THR_FC, 0, 0, 0, 0, 0);
+	
+	// Configure nipple
+	MapAxis(&Throttle, SCX, MOUSE_X_AXIS, AXIS_NORMAL, MAP_RELATIVE);
+	SetSCurve(&Throttle, SCX, 0, 0, 0, 20, -5);
+	MapAxis(&Throttle, SCY, MOUSE_Y_AXIS, AXIS_NORMAL, MAP_RELATIVE);
+	SetSCurve(&Throttle, SCY, 0, 0, 0, 20, -5);
+	
+	MapKey(&Throttle, SC, MOUSE_LEFT);
 
 	// Configure buttons
 	SetShiftButton(0, 0, &Throttle, BSF, BSB, 0);
@@ -48,13 +55,41 @@ int main() {
 	MapKeyIOUMD(&Throttle, CHF, PULSE+'y', PULSE+'y', PULSE+'y', PULSE+'y', PULSE+'y', PULSE+'y');
 	MapKeyIOUMD(&Throttle, CHB, PULSE+'h', PULSE+'h', PULSE+'h', PULSE+'h', PULSE+'h', PULSE+'h');
 
-	MapKeyIOUMD(&Throttle, EORMOTOR, HOME, HOME, HOME, HOME, HOME, HOME);
+	MapKey(&Throttle, EORMOTOR, PULSE+HOME);
+	MapKey(&Throttle, EORNORM, PULSE+HOME);
 	MapKeyIOUMD(&Throttle, EORIGN, PULSE+END, PULSE+END, PULSE+END, PULSE+END, PULSE+END, PULSE+END);
 
 	MapKeyIOUMD(&Throttle, LDGH, PULSE+'l', PULSE+'l', PULSE+'l', PULSE+'l', PULSE+'l', PULSE+'l');
 
 	MapKeyIOUMD(&Throttle, EACON, PULSE+INS, PULSE+INS, PULSE+INS, PULSE+INS, PULSE+INS, PULSE+INS);
 	MapKeyRIOUMD(&Throttle, EACON, PULSE+INS, PULSE+INS, PULSE+INS, PULSE+INS, PULSE+INS, PULSE+INS);
+	
+	MapKey(&Throttle, RDRNRM, PULSE+L_SHIFT+'\'');
+	MapKey(&Throttle, RDRDIS, PULSE+L_SHIFT+'\'');
+	
+	// Configure switches
+	MapKey(&Throttle, APUON, PULSE+L_CTL+L_ALT+'g'); //Enable/disable UI
+	MapKey(&Throttle, APUOFF, PULSE+L_CTL+L_ALT+'g'); //Enable/disable UI
+	MapKey(&Throttle, EFROVER, DX1); //Primary hardpoint enable switch
+	MapKey(&Throttle, EFLOVER, DX6); //Secondary hardpoint enable switch
+	
+	//Left engine switch doesn't have an obvious use, but
+	MapKey(&Throttle, EOLIGN, DX22);	//Lateral thrusters up, because when landed on planets
+										//that's as close to engines on as we can get
+	MapKey(&Throttle, EOLMOTOR, DX4); 	//Flight assist off because that's as close
+										//to engines off as we can get
+	
+	// Countermeasure management
+	countermeasure_commands = LIST(0, 'z', 'x', 'c'); //Chaff, heatsink, shield cell
+	selected_countermeasure = 2; //Switch rests naturally in the middle position
+	
+	MapKey(&Throttle, BSF, EXEC("selected_countermeasure = 1;"));
+	MapKey(&Throttle, BSM, EXEC("selected_countermeasure = 2;"));
+	MapKey(&Throttle, BSB, EXEC("selected_countermeasure = 3;"));
+	
+	MapKey(&Throttle, SPDB, EXEC(
+		"ActKey(fire_countermeasure_code());"
+	));
 
 	// Wingman management
 	wingman_selection_keys = LIST(0, '7', '8', '9'); // 0 is dummy
@@ -97,6 +132,10 @@ int main() {
 		"	ActKey( X(FSD_commands, FSD_mode) );"
 		"}"
 	) );
+}
+
+int fire_countermeasure_code() {
+	return KEYON+PULSE+X(countermeasure_commands, selected_countermeasure);
 }
 
 int target_selected_wingman_code() {

--- a/v2.0/ThrustMaster Warthog Combined.1.8.binds
+++ b/v2.0/ThrustMaster Warthog Combined.1.8.binds
@@ -295,7 +295,9 @@
 		<ToggleOn Value="1" />
 	</DisableRotationCorrectToggle>
 	<OrbitLinesToggle>
-		<Primary Device="{NoDevice}" Key="" />
+		<Primary Device="Keyboard" Key="Key_Apostrophe">
+			<Modifier Device="Keyboard" Key="Key_LeftShift" />
+		</Primary>
 		<Secondary Device="{NoDevice}" Key="" />
 	</OrbitLinesToggle>
 	<SelectTarget>
@@ -335,7 +337,7 @@
 		<Secondary Device="{NoDevice}" Key="" />
 	</TargetWingman2>
 	<SelectTargetsTarget>
-		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_9" />
+		<Primary Device="Keyboard" Key="Key_0" />
 		<Secondary Device="{NoDevice}" Key="" />
 	</SelectTargetsTarget>
 	<WingNavLock>
@@ -352,7 +354,7 @@
 	</CyclePreviousSubsystem>
 	<GunsightSystem />
 	<TargetNextRouteSystem>
-		<Primary Device="{NoDevice}" Key="" />
+		<Primary Device="Keyboard" Key="Key_Hash" />
 		<Secondary Device="{NoDevice}" Key="" />
 	</TargetNextRouteSystem>
 	<PrimaryFire>
@@ -361,7 +363,7 @@
 	</PrimaryFire>
 	<SecondaryFire>
 		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_6" />
-		<Secondary Device="{NoDevice}" Key="" />
+		<Secondary Device="ThrustMasterWarthogCombined" Key="Joy_3" />
 	</SecondaryFire>
 	<CycleFireGroupNext>
 		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_5" />
@@ -378,11 +380,11 @@
 	<DeployHardpointsOnFire Value="0" />
 	<ToggleButtonUpInput>
 		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_31" />
-		<Secondary Device="{NoDevice}" Key="" />
+		<Secondary Device="Keyboard" Key="Key_PageDown" />
 		<ToggleOn Value="0" />
 	</ToggleButtonUpInput>
 	<DeployHeatSink>
-		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_32" />
+		<Primary Device="Keyboard" Key="Key_X" />
 		<Secondary Device="ThrustMasterWarthogCombined" Key="Joy_27" />
 	</DeployHeatSink>
 	<ShipSpotLightToggle>
@@ -392,7 +394,7 @@
 	<RadarRangeAxis>
 		<Binding Device="ThrustMasterWarthogCombined" Key="Joy_VAxis" />
 		<Inverted Value="0" />
-		<Deadzone Value="0.12965342" />
+		<Deadzone Value="0.00000000" />
 	</RadarRangeAxis>
 	<RadarIncreaseRange>
 		<Primary Device="{NoDevice}" Key="" />
@@ -425,7 +427,7 @@
 	<ToggleCargoScoop>
 		<Primary Device="Keyboard" Key="Key_Home" />
 		<Secondary Device="{NoDevice}" Key="" />
-		<ToggleOn Value="0" />
+		<ToggleOn Value="1" />
 	</ToggleCargoScoop>
 	<EjectAllCargo>
 		<Primary Device="Keyboard" Key="Key_End" />
@@ -442,11 +444,11 @@
 	<MuteButtonMode Value="mute_toggle" />
 	<CqcMuteButtonMode Value="mute_pushToTalk" />
 	<UseShieldCell>
-		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_28" />
+		<Primary Device="Keyboard" Key="Key_Z" />
 		<Secondary Device="{NoDevice}" Key="" />
 	</UseShieldCell>
 	<FireChaffLauncher>
-		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_30" />
+		<Primary Device="Keyboard" Key="Key_C" />
 		<Secondary Device="{NoDevice}" Key="" />
 	</FireChaffLauncher>
 	<PhotoCameraToggle>
@@ -454,7 +456,7 @@
 		<Secondary Device="{NoDevice}" Key="" />
 	</PhotoCameraToggle>
 	<UIFocus>
-		<Primary Device="{NoDevice}" Key="" />
+		<Primary Device="Keyboard" Key="Key_LeftShift" />
 		<Secondary Device="{NoDevice}" Key="" />
 	</UIFocus>
 	<UIFocusMode Value="Bindings_FocusModeHold" />
@@ -529,7 +531,7 @@
 		<Secondary Device="{NoDevice}" Key="" />
 	</UI_Select>
 	<UI_Back>
-		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_9" />
+		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_7" />
 		<Secondary Device="{NoDevice}" Key="" />
 	</UI_Back>
 	<CycleNextPanel>
@@ -713,7 +715,7 @@
 		<Secondary Device="{NoDevice}" Key="" />
 	</BuggyPitchDownButton>
 	<VerticalThrustersButton>
-		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_21" />
+		<Primary Device="ThrustMasterWarthogCombined" Key="Joy_22" />
 		<Secondary Device="{NoDevice}" Key="" />
 		<ToggleOn Value="0" />
 	</VerticalThrustersButton>
@@ -774,7 +776,7 @@
 	</BuggyTurretPitchDownButton>
 	<DriveSpeedAxis>
 		<Binding Device="ThrustMasterWarthogCombined" Key="Joy_ZAxis" />
-		<Inverted Value="0" />
+		<Inverted Value="1" />
 		<Deadzone Value="0.00000000" />
 	</DriveSpeedAxis>
 	<BuggyThrottleRange Value="Bindings_BuggyThrottleForewardOnly" />


### PR DESCRIPTION
- Map throttle trackball to mouse
- SPDB fires countermeasures, switched via boat switch beneath.
- Additionally, EOL switch given closest available functionality, with
  engines up and flight assist.
- Override switches now override hardpoint activation, making it easier
  to lock them on.
- APU switch now controls silent running.
